### PR TITLE
Fix a critical bug not killing old workers with HUP signal

### DIFF
--- a/lib/server/starter.rb
+++ b/lib/server/starter.rb
@@ -313,7 +313,7 @@ class Server::Starter
             sleep kill_old_delay
           end
           $stderr.puts "killing old workers"
-          @old_workers.keys.sort {|pid| Process.kill(opts[:signal_on_hup], pid) }
+          @old_workers.keys.sort.each {|pid| Process.kill(opts[:signal_on_hup], pid) }
         end
       end
     end


### PR DESCRIPTION
It was not killing old workers on HUP :scream: 
